### PR TITLE
Support to replace APKs in an Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,34 @@ upload. If you'd like to contribute more behaviours then...
 ## Getting started
 
 1. Create an Amazon Security Profile by following the instructions [here](https://developer.amazon.com/docs/app-submission-api/auth.html)
+    - Then create a Security Profile json file like the following:
+      ```json
+      {
+          "grant_type": "client_credentials",
+          "client_id": "amzn1.application-oa2-client.ae941846cdd745e9a53319f7bb98d435",
+          "client_secret": "41d135b2b02ce5f2fbf7643a66477c089fcc1d88d11f69d3e4a6285b917ca35d",
+          "scope": "appstore::apps:readwrite"
+      }
+      ```
 2. Read the Amazon Publishing API overview [here](https://developer.amazon.com/docs/app-submission-api/overview.html)
 3. Add the plugin to your project following the instructions [here](https://plugins.gradle.org/plugin/app.brant.amazonappstorepublisher)
-4. Add the `amazon { }` closure to the module that creates your APK and specify the following attributes;
-    ```
+4. Add the `amazon { }` closure to the module that creates your APK and specify the following attributes:
+    ```groovy
     amazon {
         securityProfile = file("<path-to-security-profile.json>")
         applicationId = "<applicationId>"
         pathToApks = [ file("<path-to-apk>") ]
-        replaceEdit = true
+        replaceEdit = true // true if you want to delete any existing Edit ("Upcoming version")
+        replaceApks = true // true if you want to replace existing apks in an Edit ("Upcoming version")
     }
     ```
     All paths are relative.
     
 5. Run `gradlew publishToAmazonAppStore`
+    - For large files or slow networks, you might need to increase the read and write timeouts in seconds by setting `app.brant.amazonappstorepublisher.PublishPlugin.writeTimeout` or `app.brant.amazonappstorepublisher.PublishPlugin.readTimeout` jvm properties
+        - e.g.
+          ```bash
+          gradlew -Dapp.brant.amazonappstorepublisher.PublishPlugin.writeTimeout=600 -Dapp.brant.amazonappstorepublisher.PublishPlugin.readTimeout=300 publishToAmazonAppStore
+          ```
 6. Add it to your Continuous Deployment pipeline
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "app.brant"
-version = "0.1.0"
+version = "0.1.1"
 
 val pluginArtifactId = "amazonappstorepublisher"
 val pluginVcsUrl = "https://github.com/BrantApps/gradle-amazon-app-store-publisher"

--- a/plugin/src/main/kotlin/app/brant/amazonappstorepublisher/PublishPluginExtension.kt
+++ b/plugin/src/main/kotlin/app/brant/amazonappstorepublisher/PublishPluginExtension.kt
@@ -17,6 +17,9 @@ open class PublishPluginExtension @JvmOverloads constructor(
     internal var replaceEditProp: Boolean? = null
 
     @get:Internal("Backing property for public input")
+    internal var replaceApksProp: Boolean? = null
+
+    @get:Internal("Backing property for public input")
     internal var applicationIdProp: String? = null
 
     @get:Internal("Backing property for public input")
@@ -50,5 +53,12 @@ open class PublishPluginExtension @JvmOverloads constructor(
         get() = replaceEditProp ?: true
         set(value) {
             replaceEditProp = value
+        }
+
+    @get:Input
+    var replaceApks
+        get() = replaceApksProp ?: false
+        set(value) {
+            replaceApksProp = value
         }
 }


### PR DESCRIPTION
### About
Adding support to replace existing apks in an Edit. The API call was taken from the [sample calls](https://developer.amazon.com/docs/app-submission-api/python-example.html) in the docs.

### In this PR
- also surfaced any possible errors during the apk deletion process [here](https://github.com/BrantApps/gradle-amazon-app-store-publisher/compare/master...ccaruceru:master#diff-01ee7018e7f7be98df4bf6c04b89c625e2854bb675a61fdfd3539db84d458e81R138-R141), which is most likely the symptom for #6 
    - the changes in this PR act as a workaround for the above issue.  (_perhaps the API call changed? if so, I can't surface any relevant docs for it_)
- add support to override the `OkHttpClient` read and write timeouts from command line with jvm properties
- bump plugin version to `0.1.1`
- updated Readme